### PR TITLE
codeQL v6 updates

### DIFF
--- a/app/api/routers/chapters.py
+++ b/app/api/routers/chapters.py
@@ -12,7 +12,7 @@ from ...db import (
     sync_chapter_segments, reset_chapter_audio, get_connection
 )
 from ... import config
-from ...config import get_project_audio_dir, SENT_CHAR_LIMIT, BASELINE_XTTS_CPS
+from ...config import SENT_CHAR_LIMIT, BASELINE_XTTS_CPS, find_existing_project_subdir
 from ...textops import (
     compute_chapter_metrics, sanitize_for_xtts,
     safe_split_long_sentences, pack_text_to_limit
@@ -49,8 +49,8 @@ def _named_file(base_dir: Path, filename: str, allowed_suffixes: Optional[tuple[
     return None
 
 
-def _named_audio_file_map(base_dir: Path) -> dict[str, Path]:
-    if not base_dir.exists():
+def _named_audio_file_map(base_dir: Optional[Path]) -> dict[str, Path]:
+    if not base_dir or not base_dir.exists():
         return {}
     return {
         entry.name: entry.resolve()
@@ -351,7 +351,7 @@ async def api_export_chapter_sample(
 ):
     chapter = get_chapter(chapter_id)
     pdir = (
-        get_project_audio_dir(project_id) if project_id else xtts_out_dir
+        find_existing_project_subdir(project_id, "audio") if project_id else xtts_out_dir
     )
 
     wav_path = None
@@ -387,7 +387,7 @@ def api_stream_chapter(
 ):
     chapter = get_chapter(chapter_id)
     pdir = (
-        get_project_audio_dir(project_id) if project_id else xtts_out_dir
+        find_existing_project_subdir(project_id, "audio") if project_id else xtts_out_dir
     )
 
     wav_path = None

--- a/app/api/routers/generation.py
+++ b/app/api/routers/generation.py
@@ -12,9 +12,7 @@ from ...db import (
 from ...jobs import enqueue, cancel as cancel_job_worker, set_paused, clear_job_queue
 from ...models import Job
 from ...state import put_job, update_job, get_settings, get_jobs
-from ...config import get_project_text_dir
-from ...config import get_project_audio_dir, XTTS_OUT_DIR
-from ...pathing import safe_join_flat
+from ...config import XTTS_OUT_DIR, find_existing_project_dir, find_existing_project_subdir
 from ..ws import broadcast_queue_update
 
 router = APIRouter(prefix="/api", tags=["generation"])
@@ -50,13 +48,17 @@ def api_add_to_queue(
 
         if c_item:
             title, text_content = c_item
-            text_dir = get_project_text_dir(project_id)
+            project_dir = find_existing_project_dir(project_id)
+            if not project_dir:
+                raise ValueError(f"Project directory not found for {project_id}")
+            text_dir = find_existing_project_subdir(project_id, "text") or (project_dir / "text")
+            text_dir.mkdir(parents=True, exist_ok=True)
             temp_filename = f"{chapter_id}_{split_part}.txt"
             temp_path = text_dir / temp_filename
             temp_path.write_text(text_content or "", encoding="utf-8", errors="replace")
 
             segs = get_chapter_segments(chapter_id)
-            pdir = get_project_audio_dir(project_id)
+            pdir = find_existing_project_subdir(project_id, "audio") or (project_dir / "audio")
             project_audio_files = {
                 entry.name
                 for entry in pdir.iterdir()
@@ -222,15 +224,17 @@ def api_generate_segments(segment_ids: str = Form(...)):
 
     # Physical Cleanup: Delete existing full-chapter audio files to prevent reconciliation "blink"
     from ... import config
-    pdir = config.get_project_audio_dir(project_id) if project_id else config.XTTS_OUT_DIR
-    for p in pdir.iterdir():
+    project_audio_dir = config.find_existing_project_subdir(project_id, "audio") if project_id else config.XTTS_OUT_DIR
+    if not project_audio_dir:
+        project_audio_dir = config.get_project_dir(project_id) / "audio"
+    for p in project_audio_dir.iterdir() if project_audio_dir.exists() else ():
         if (
             p.is_file()
             and p.name.startswith(chapter_id)
             and p.suffix.lower() in ('.wav', '.mp3', '.m4a')
         ):
             try:
-                safe_join_flat(pdir, p.name).unlink()
+                p.unlink()
             except Exception:
                 logger.warning("Failed to remove stale chapter audio file %s", p, exc_info=True)
 

--- a/app/api/routers/projects.py
+++ b/app/api/routers/projects.py
@@ -11,7 +11,7 @@ from ...db import (
     create_project, get_project, list_projects, update_project, 
     delete_project, list_chapters as db_list_chapters, reorder_chapters
 )
-from ...config import COVER_DIR, XTTS_OUT_DIR, get_project_dir, get_project_m4b_dir
+from ...config import COVER_DIR, XTTS_OUT_DIR, get_project_dir, find_existing_project_subdir
 import urllib.parse
 from ...jobs import enqueue
 from ...engines import get_audio_duration
@@ -110,9 +110,9 @@ def api_list_project_audiobooks(project_id: str):
     if not project:
         return JSONResponse({"status": "error", "message": "Project not found"}, status_code=404)
 
-    m4b_dir = get_project_m4b_dir(project_id)
+    m4b_dir = find_existing_project_subdir(project_id, "m4b")
     m4b_files = []
-    if m4b_dir.exists():
+    if m4b_dir and m4b_dir.exists():
         for p in m4b_dir.iterdir():
             if not p.is_file() or p.suffix.lower() != ".m4b":
                 continue

--- a/app/api/routers/settings.py
+++ b/app/api/routers/settings.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Optional, List
 from fastapi import APIRouter, Query
 from fastapi.responses import JSONResponse
-from ...config import AUDIOBOOK_DIR, PROJECTS_DIR
+from ...config import AUDIOBOOK_DIR, PROJECTS_DIR, find_existing_project_subdir
 from ...state import get_jobs, put_job, update_job
 from ...jobs import enqueue
 from ...models import Job
@@ -21,14 +21,13 @@ def api_list_audiobooks():
 
 @router.delete("/audiobook/{filename}")
 def delete_audiobook(filename: str, project_id: Optional[str] = Query(None)):
-    from ...config import get_project_m4b_dir
     path = None
     if project_id:
         try:
             if not SAFE_AUDIOBOOK_NAME_RE.fullmatch(filename):
                 raise ValueError(f"Invalid filename: {filename}")
-            project_m4b_dir = get_project_m4b_dir(project_id)
-            if project_m4b_dir.exists():
+            project_m4b_dir = find_existing_project_subdir(project_id, "m4b")
+            if project_m4b_dir and project_m4b_dir.exists():
                 path = next(
                     (entry.resolve() for entry in project_m4b_dir.iterdir() if entry.is_file() and entry.name == filename),
                     None

--- a/app/api/routers/system.py
+++ b/app/api/routers/system.py
@@ -191,8 +191,6 @@ async def create_audiobook(
     narrator: str = Form(None),
     chapters: str = Form("[]"),
     cover: Optional[UploadFile] = File(None),
-    cover_dir: Path = Depends(get_cover_dir),
-    audiobook_dir: Path = Depends(get_audiobook_dir)
 ):
     try:
         chapter_list = json.loads(chapters)
@@ -200,6 +198,8 @@ async def create_audiobook(
         logger.warning("Invalid chapters payload for audiobook creation", exc_info=True)
         chapter_list = []
 
+    cover_dir = config.COVER_DIR
+    audiobook_dir = config.AUDIOBOOK_DIR
     cover_dir.mkdir(parents=True, exist_ok=True)
     audiobook_dir.mkdir(parents=True, exist_ok=True)
 

--- a/app/config.py
+++ b/app/config.py
@@ -27,49 +27,65 @@ def _canonical_project_id(project_id: str) -> str:
             return project_id
         raise ValueError(f"Invalid project id: {project_id}")
 
-def get_project_dir(project_id: str) -> Path:
-    canonical_project_id = _canonical_project_id(project_id)
 
-    if PROJECTS_DIR.exists():
+def find_existing_project_dir(project_id: str) -> Path | None:
+    canonical_project_id = _canonical_project_id(project_id)
+    if not PROJECTS_DIR.exists():
+        return None
+    try:
         for entry in PROJECTS_DIR.iterdir():
             if entry.is_dir() and entry.name == canonical_project_id:
                 return entry.resolve()
+    except OSError:
+        return None
+    return None
 
-    PROJECTS_DIR.mkdir(parents=True, exist_ok=True)
+
+def find_existing_project_subdir(project_id: str, dirname: str) -> Path | None:
+    project_dir = find_existing_project_dir(project_id)
+    if not project_dir or not project_dir.exists():
+        return None
+    try:
+        for entry in project_dir.iterdir():
+            if entry.is_dir() and entry.name == dirname:
+                return entry.resolve()
+    except OSError:
+        return None
+    return None
+
+
+def get_project_dir(project_id: str) -> Path:
+    canonical_project_id = _canonical_project_id(project_id)
+    existing_dir = find_existing_project_dir(canonical_project_id)
+    if existing_dir:
+        return existing_dir
+
     projects_root = os.fspath(PROJECTS_DIR.resolve())
     fullpath = os.path.abspath(os.path.normpath(os.path.join(projects_root, canonical_project_id)))
     if not fullpath.startswith(projects_root + os.sep) and fullpath != projects_root:
         raise ValueError(f"Invalid project id: {project_id}")
-    d = Path(fullpath)
-    d.mkdir(parents=True, exist_ok=True)
-    return d
+    return Path(fullpath)
 
 def get_project_audio_dir(project_id: str) -> Path:
+    existing_dir = find_existing_project_subdir(project_id, "audio")
+    if existing_dir:
+        return existing_dir
     project_dir = get_project_dir(project_id)
-    for entry in project_dir.iterdir():
-        if entry.is_dir() and entry.name == "audio":
-            return entry.resolve()
-    d = project_dir / "audio"
-    d.mkdir(parents=True, exist_ok=True)
-    return d
+    return project_dir / "audio"
 
 def get_project_text_dir(project_id: str) -> Path:
+    existing_dir = find_existing_project_subdir(project_id, "text")
+    if existing_dir:
+        return existing_dir
     project_dir = get_project_dir(project_id)
-    for entry in project_dir.iterdir():
-        if entry.is_dir() and entry.name == "text":
-            return entry.resolve()
-    d = project_dir / "text"
-    d.mkdir(parents=True, exist_ok=True)
-    return d
+    return project_dir / "text"
 
 def get_project_m4b_dir(project_id: str) -> Path:
+    existing_dir = find_existing_project_subdir(project_id, "m4b")
+    if existing_dir:
+        return existing_dir
     project_dir = get_project_dir(project_id)
-    for entry in project_dir.iterdir():
-        if entry.is_dir() and entry.name == "m4b":
-            return entry.resolve()
-    d = project_dir / "m4b"
-    d.mkdir(parents=True, exist_ok=True)
-    return d
+    return project_dir / "m4b"
 
 
 # Your existing environments (adjust only if different)

--- a/app/db/chapters.py
+++ b/app/db/chapters.py
@@ -19,7 +19,9 @@ def cleanup_chapter_audio_files(
     """Delete chapter-level and selected segment audio files without touching DB state."""
     from .. import config
 
-    pdir = config.get_project_audio_dir(project_id) if project_id else config.XTTS_OUT_DIR
+    pdir = config.find_existing_project_subdir(project_id, "audio") if project_id else config.XTTS_OUT_DIR
+    if project_id and not pdir:
+        return True
     resolved_root = pdir.resolve()
     known_files = {
         entry.name: entry.resolve()
@@ -119,12 +121,12 @@ def get_chapter(chapter_id: str) -> Optional[Dict[str, Any]]:
 
     # Rule 3: Disk as Source of Truth - Outside Lock
     from .. import config
-    pdir = config.get_project_audio_dir(chap["project_id"]) if chap["project_id"] else config.XTTS_OUT_DIR
+    pdir = config.find_existing_project_subdir(chap["project_id"], "audio") if chap["project_id"] else config.XTTS_OUT_DIR
     existing_names = {
         entry.name
         for entry in pdir.iterdir()
         if entry.is_file() and entry.suffix.lower() in (".wav", ".mp3", ".m4a")
-    } if pdir.exists() else set()
+    } if pdir and pdir.exists() else set()
     path = chap.get("audio_file_path")
     chap["has_wav"] = False
     chap["has_mp3"] = False
@@ -161,13 +163,13 @@ def list_chapters(project_id: str) -> List[Dict[str, Any]]:
             rows = [dict(row) for row in cursor.fetchall()]
 
     from .. import config
-    pdir = config.get_project_audio_dir(project_id) if project_id else config.XTTS_OUT_DIR
+    pdir = config.find_existing_project_subdir(project_id, "audio") if project_id else config.XTTS_OUT_DIR
 
     existing_names = {
         entry.name
         for entry in pdir.iterdir()
         if entry.is_file() and entry.suffix.lower() in (".wav", ".mp3", ".m4a")
-    } if pdir.exists() else set()
+    } if pdir and pdir.exists() else set()
 
     for chap in rows:
         path = chap.get("audio_file_path")

--- a/app/db/projects.py
+++ b/app/db/projects.py
@@ -7,6 +7,8 @@ from .core import _db_lock, get_connection
 logger = logging.getLogger(__name__)
 
 def create_project(name: str, series: Optional[str] = None, author: Optional[str] = None, cover_image_path: Optional[str] = None) -> str:
+    from .. import config
+
     with _db_lock:
         with get_connection() as conn:
             cursor = conn.cursor()
@@ -17,6 +19,12 @@ def create_project(name: str, series: Optional[str] = None, author: Optional[str
                 VALUES (?, ?, ?, ?, ?, ?, ?)
             """, (project_id, name, series, author, cover_image_path, now, now))
             conn.commit()
+
+            project_dir = config.PROJECTS_DIR / project_id
+            (project_dir / "audio").mkdir(parents=True, exist_ok=True)
+            (project_dir / "text").mkdir(parents=True, exist_ok=True)
+            (project_dir / "m4b").mkdir(parents=True, exist_ok=True)
+
             return project_id
 
 def get_project(project_id: str) -> Optional[Dict[str, Any]]:

--- a/app/db/reconcile.py
+++ b/app/db/reconcile.py
@@ -2,7 +2,6 @@ import os
 import subprocess
 import logging
 from .core import _db_lock, get_connection
-from ..pathing import safe_join_flat
 
 logger = logging.getLogger(__name__)
 
@@ -11,19 +10,22 @@ def reconcile_project_audio(project_id: str):
     Scans the project's audio directory and updates the database if audio files exist 
     but the chapter status is not 'done'.
     """
-    from ..config import get_project_audio_dir
-    audio_dir = get_project_audio_dir(project_id)
-    if not audio_dir.exists():
+    from ..config import find_existing_project_subdir
+    audio_dir = find_existing_project_subdir(project_id, "audio")
+    if not audio_dir or not audio_dir.exists():
         return
+
+    all_audio_paths = {
+        entry.name: entry.resolve()
+        for entry in audio_dir.iterdir()
+        if entry.is_file()
+    }
 
     with _db_lock:
         with get_connection() as conn:
             cursor = conn.cursor()
             cursor.execute("SELECT id, audio_status, audio_length_seconds FROM chapters WHERE project_id = ?", (project_id,))
             chapters = cursor.fetchall()
-
-            # Get list of all files to avoid redundant filesystem calls
-            all_files = os.listdir(audio_dir)
 
             for cid, status, length in chapters:
                 if status not in ('done', 'unprocessed'):
@@ -32,7 +34,7 @@ def reconcile_project_audio(project_id: str):
                 # Find candidate files matching the chapter ID prefix
                 # We filter for common audio extensions and ensure it's not a segment
                 candidates = [
-                    f for f in all_files 
+                    f for f in all_audio_paths
                     if f.startswith(cid) and f.lower().endswith(('.wav', '.mp3', '.m4a'))
                 ]
 
@@ -64,7 +66,9 @@ def reconcile_project_audio(project_id: str):
                     duration = length or 0.0
                     if duration == 0.0 or current_path != best_file:
                         try:
-                            audio_path = safe_join_flat(audio_dir, best_file)
+                            audio_path = all_audio_paths.get(best_file)
+                            if not audio_path:
+                                raise FileNotFoundError(best_file)
                             result = subprocess.run(
                                 ["ffprobe", "-v", "error", "-show_entries", "format=duration", "-of", "default=noprint_wrappers=1:nokey=1", str(audio_path)],
                                 stdout=subprocess.PIPE,

--- a/app/db/speakers.py
+++ b/app/db/speakers.py
@@ -1,6 +1,7 @@
 import time
 import uuid
 import logging
+import os
 import re
 from pathlib import Path
 from typing import List, Dict, Any, Optional
@@ -130,13 +131,29 @@ def create_speaker(name: str, default_profile_name: Optional[str] = None) -> str
             """, (speaker_id, name, default_profile_name, now, now))
             conn.commit()
 
+            voices_root = os.path.abspath(os.path.normpath(os.fspath(config.VOICES_DIR.resolve())))
+            existing_dirs: dict[str, Path] = {}
+            if config.VOICES_DIR.exists():
+                try:
+                    for entry in config.VOICES_DIR.iterdir():
+                        if entry.is_dir():
+                            existing_dirs[entry.name] = entry.resolve()
+                except OSError:
+                    existing_dirs = {}
+
             # Legacy sync: ensure profile directory exists and linked
             pname = default_profile_name or name
             try:
-                profile_dir = _existing_profile_dir(config.VOICES_DIR, pname) or _new_profile_dir(config.VOICES_DIR, pname)
+                pname = _profile_name_or_error(pname)
             except ValueError:
                 pname = f"speaker-{speaker_id}"
-                profile_dir = _new_profile_dir(config.VOICES_DIR, pname)
+
+            profile_dir = existing_dirs.get(pname)
+            if not profile_dir:
+                profile_path = os.path.abspath(os.path.normpath(os.path.join(voices_root, pname)))
+                if not profile_path.startswith(voices_root + os.sep) and profile_path != voices_root:
+                    raise ValueError(f"Invalid profile directory for {pname}")
+                profile_dir = Path(profile_path)
 
             # Collision handling: if directory belongs to ANOTHER speaker, use a suffix
             if profile_dir.exists():
@@ -147,10 +164,13 @@ def create_speaker(name: str, default_profile_name: Optional[str] = None) -> str
                         if "speaker_id" in existing_meta and existing_meta["speaker_id"] != speaker_id:
                             # Suffix logic
                             idx = 1
-                            while _existing_profile_dir(config.VOICES_DIR, f"{pname}_{idx}"):
+                            while f"{pname}_{idx}" in existing_dirs:
                                 idx += 1
                             pname = f"{pname}_{idx}"
-                            profile_dir = _new_profile_dir(config.VOICES_DIR, pname)
+                            profile_path = os.path.abspath(os.path.normpath(os.path.join(voices_root, pname)))
+                            if not profile_path.startswith(voices_root + os.sep) and profile_path != voices_root:
+                                raise ValueError(f"Invalid profile directory for {pname}")
+                            profile_dir = Path(profile_path)
                     except Exception:
                         logger.debug("Failed to inspect existing voice profile metadata for %s", profile_dir, exc_info=True)
 

--- a/app/textops.py
+++ b/app/textops.py
@@ -50,7 +50,6 @@ from .config import SAFE_SPLIT_TARGET, SENT_CHAR_LIMIT, BASELINE_XTTS_CPS
 # merges short sentences with ";" which naturally becomes a pause in the audio.
 
 CHAPTER_RE = re.compile(r"^(Chapter\s+(\d+)\s*:\s*.+)$", re.MULTILINE)
-SENT_SPLIT_RE = re.compile(r'(.+?(?:[.!?]["\'”’]*(?=\s|$)|\n+))(\s*)', re.DOTALL)
 
 def normalize_newlines(text: str) -> str:
     """
@@ -167,26 +166,62 @@ def split_sentences(text: str, preserve_gap: bool = False):
     Splits text into (sentence, start_idx, end_idx).
     If preserve_gap is True, the sentence will include its trailing whitespace/newlines.
     """
-    last_end = 0
-    for m in SENT_SPLIT_RE.finditer(text):
-        if preserve_gap:
-            # Full match includes the trailing space group
-            s = m.group(0)
-            yield s, m.start(0), m.end(0)
-        else:
-            s = m.group(1)
-            # Strip leading space and trailing horizontal space, 
-            # but keep the newline if it's the paragraph marker for the frontend.
-            s = s.strip(" \t\r")
-            if s:
-                yield s, m.start(1), m.start(1) + len(s)
-        last_end = m.end()
+    if not text:
+        return
 
-    remainder = text[last_end:]
+    start = 0
+    i = 0
+    text_len = len(text)
+    closing_quotes = {'"', "'", "”", "’"}
+
+    while i < text_len:
+        split_end = None
+
+        if text[i] in ".!?":
+            j = i + 1
+            while j < text_len and text[j] in closing_quotes:
+                j += 1
+            if j == text_len or text[j].isspace():
+                split_end = j
+        elif text[i] == "\n":
+            j = i + 1
+            while j < text_len and text[j] == "\n":
+                j += 1
+            split_end = j
+
+        if split_end is None:
+            i += 1
+            continue
+
+        gap_end = split_end
+        while gap_end < text_len and text[gap_end].isspace():
+            gap_end += 1
+
+        if preserve_gap:
+            sentence = text[start:gap_end]
+            if sentence:
+                yield sentence, start, gap_end
+        else:
+            raw_sentence = text[start:split_end]
+            sentence = raw_sentence.strip(" \t\r")
+            if sentence:
+                leading_trim = len(raw_sentence) - len(raw_sentence.lstrip(" \t\r"))
+                sentence_start = start + leading_trim
+                yield sentence, sentence_start, sentence_start + len(sentence)
+
+        start = gap_end
+        i = gap_end
+
+    remainder = text[start:]
     if remainder.strip() or (preserve_gap and remainder):
-        if not preserve_gap:
-            remainder = remainder.strip()
-        yield remainder, last_end, last_end + len(remainder)
+        if preserve_gap:
+            yield remainder, start, start + len(remainder)
+        else:
+            trimmed = remainder.strip()
+            if trimmed:
+                leading_trim = len(remainder) - len(remainder.lstrip())
+                sentence_start = start + leading_trim
+                yield trimmed, sentence_start, sentence_start + len(trimmed)
 
 def safe_split_long_sentences(text: str, target: int = SAFE_SPLIT_TARGET) -> str:
     def split_one(s: str) -> List[str]:

--- a/app/web.py
+++ b/app/web.py
@@ -58,8 +58,6 @@ async def legacy_create_audiobook(request: Request):
         narrator=form.get("narrator"),
         chapters=form.get("chapters", "[]"),
         cover=form.get("cover"),
-        cover_dir=COVER_DIR,
-        audiobook_dir=AUDIOBOOK_DIR
     )
 
 @app.post("/settings")

--- a/tests/test_api_generation.py
+++ b/tests/test_api_generation.py
@@ -96,7 +96,8 @@ def test_queue_chapter_preserves_rendered_segment_history(clean_db, client, tmp_
     update_segment(segs[0]["id"], audio_status="done", audio_file_path=rendered_name)
     update_segment(segs[1]["id"], audio_status="unprocessed", audio_file_path=None)
 
-    with patch("app.api.routers.generation.get_project_audio_dir", return_value=audio_dir), \
+    with patch("app.api.routers.generation.find_existing_project_dir", return_value=tmp_path), \
+         patch("app.api.routers.generation.find_existing_project_subdir", side_effect=lambda _project_id, dirname: audio_dir if dirname == "audio" else None), \
          patch("app.config.get_project_audio_dir", return_value=audio_dir), \
          patch("app.api.routers.generation.put_job") as mock_put_job, \
          patch("app.api.routers.generation.enqueue"):

--- a/tests/test_db_chapters.py
+++ b/tests/test_db_chapters.py
@@ -9,6 +9,10 @@ from app.db.chapters import (
 )
 from app.db.projects import create_project
 
+
+def _existing_project_audio_dir(path: Path):
+    return lambda _project_id, dirname: Path(path) if dirname == "audio" else None
+
 @pytest.fixture
 def db_conn():
     db_path = "/tmp/test_audiobook.db"
@@ -75,7 +79,8 @@ def test_get_chapter_disk_checks(db_conn, tmp_path):
     (audio_dir / f"{cid}.mp3").write_text("mp3")
     (audio_dir / f"{cid}.m4a").write_text("m4a")
 
-    with patch("app.config.get_project_audio_dir", return_value=Path(audio_dir)):
+    with patch("app.config.get_project_audio_dir", return_value=Path(audio_dir)), \
+         patch("app.config.find_existing_project_subdir", side_effect=_existing_project_audio_dir(audio_dir)):
 
         chapter = get_chapter(cid)
         assert chapter["has_wav"] is True
@@ -99,7 +104,8 @@ def test_reset_chapter_audio(db_conn):
     pid = create_project("P2", "/tmp")
     # Need to mock config for physical file checks in reset_chapter_audio
     from unittest.mock import patch
-    with patch("app.config.get_project_audio_dir", return_value=Path("/tmp")):
+    with patch("app.config.get_project_audio_dir", return_value=Path("/tmp")), \
+         patch("app.config.find_existing_project_subdir", side_effect=_existing_project_audio_dir(Path("/tmp"))):
         cid = create_chapter(pid, "C1")
         update_chapter(cid, audio_status="done", audio_file_path="c1.wav")
 
@@ -117,7 +123,8 @@ def test_update_segment_only_cleans_edited_segment_files(db_conn, tmp_path):
     pid = create_project("P3", "/tmp")
     cid = create_chapter(pid, "C3", "One. Two.")
 
-    with patch("app.config.get_project_audio_dir", return_value=tmp_path):
+    with patch("app.config.get_project_audio_dir", return_value=tmp_path), \
+         patch("app.config.find_existing_project_subdir", side_effect=_existing_project_audio_dir(tmp_path)):
         sync_chapter_segments(cid, "One. Two.")
         segs = get_chapter_segments(cid)
         sid1 = segs[0]["id"]
@@ -159,7 +166,8 @@ def test_update_chapter_text_change_deletes_stale_chapter_audio(db_conn, tmp_pat
     pid = create_project("P6", "/tmp")
     cid = create_chapter(pid, "C6", "One. Two.")
 
-    with patch("app.config.get_project_audio_dir", return_value=tmp_path):
+    with patch("app.config.get_project_audio_dir", return_value=tmp_path), \
+         patch("app.config.find_existing_project_subdir", side_effect=_existing_project_audio_dir(tmp_path)):
         sync_chapter_segments(cid, "One. Two.")
         segs = get_chapter_segments(cid)
         sid1 = segs[0]["id"]
@@ -202,7 +210,8 @@ def test_sync_chapter_segments_preserves_rendered_file_links(db_conn, tmp_path):
     pid = create_project("P4", "/tmp")
     cid = create_chapter(pid, "C4", "One. Two.")
 
-    with patch("app.config.get_project_audio_dir", return_value=tmp_path):
+    with patch("app.config.get_project_audio_dir", return_value=tmp_path), \
+         patch("app.config.find_existing_project_subdir", side_effect=_existing_project_audio_dir(tmp_path)):
         sync_chapter_segments(cid, "One. Two.")
         segs = get_chapter_segments(cid)
         sid1 = segs[0]["id"]
@@ -235,7 +244,8 @@ def test_sync_chapter_segments_does_not_cross_match_reordered_duplicates(db_conn
     pid = create_project("P5", "/tmp")
     cid = create_chapter(pid, "C5", "Repeat. Middle. Repeat.")
 
-    with patch("app.config.get_project_audio_dir", return_value=tmp_path):
+    with patch("app.config.get_project_audio_dir", return_value=tmp_path), \
+         patch("app.config.find_existing_project_subdir", side_effect=_existing_project_audio_dir(tmp_path)):
         sync_chapter_segments(cid, "Repeat. Middle. Repeat.")
         segs = get_chapter_segments(cid)
         first_id, middle_id, last_id = [s["id"] for s in segs]
@@ -273,7 +283,8 @@ def test_sync_chapter_segments_invalidates_trailing_segments_after_shift(db_conn
     pid = create_project("P6", "/tmp")
     cid = create_chapter(pid, "C6", "Alpha. Bravo. Charlie. Delta.")
 
-    with patch("app.config.get_project_audio_dir", return_value=tmp_path):
+    with patch("app.config.get_project_audio_dir", return_value=tmp_path), \
+         patch("app.config.find_existing_project_subdir", side_effect=_existing_project_audio_dir(tmp_path)):
         sync_chapter_segments(cid, "Alpha. Bravo. Charlie. Delta.")
         segs = get_chapter_segments(cid)
         sid1, sid2, sid3, sid4 = [s["id"] for s in segs]

--- a/tests/test_db_reconcile.py
+++ b/tests/test_db_reconcile.py
@@ -28,21 +28,16 @@ def db_conn():
     if os.path.exists(db_path):
         os.unlink(db_path)
 
-def test_reconcile_project_audio(db_conn):
+def test_reconcile_project_audio(db_conn, tmp_path):
     pid = create_project("P1")
     cid = create_chapter(pid, "C1")
 
     expected_file = f"{cid}.mp3"
+    audio_dir = tmp_path / "audio"
+    audio_dir.mkdir()
+    (audio_dir / expected_file).write_bytes(b"mp3")
 
-    def mock_exists(p_self):
-        s = str(p_self)
-        if expected_file in s or "audio" in s:
-            return True
-        return False
-
-    with patch("app.config.get_project_audio_dir", return_value=Path("/tmp/audio")), \
-         patch("pathlib.Path.exists", side_effect=mock_exists, autospec=True), \
-         patch("os.listdir", return_value=[expected_file]), \
+    with patch("app.config.find_existing_project_subdir", side_effect=lambda _project_id, dirname: audio_dir if dirname == "audio" else None), \
          patch("subprocess.run") as mock_run:
 
         # Mock ffprobe result
@@ -60,20 +55,15 @@ def test_reconcile_project_audio(db_conn):
             assert row["audio_file_path"] == expected_file
             assert row["audio_length_seconds"] == 42.0
 
-def test_reconcile_project_audio_not_found(db_conn):
+def test_reconcile_project_audio_not_found(db_conn, tmp_path):
     pid = create_project("P1")
     cid = create_chapter(pid, "C1")
     update_chapter(cid, audio_status="done", audio_file_path="old.wav")
 
-    def mock_exists(p_self):
-        s = str(p_self)
-        if s.endswith("audio"):
-            return True
-        return False
+    audio_dir = tmp_path / "audio"
+    audio_dir.mkdir()
 
-    with patch("app.config.get_project_audio_dir", return_value=Path("/tmp/audio")), \
-         patch("os.listdir", return_value=[]), \
-         patch("pathlib.Path.exists", side_effect=mock_exists, autospec=True):
+    with patch("app.config.find_existing_project_subdir", side_effect=lambda _project_id, dirname: audio_dir if dirname == "audio" else None):
 
         reconcile_project_audio(pid)
 


### PR DESCRIPTION
  - added existing-project lookup helpers
  - kept getters tolerant of missing dirs without recreating them
  - switched more project/audio flows to trusted existing-directory enumeration instead of rebuilding paths from IDs
  - removed the old legacy audiobook wrapper arg mismatch
  - made `create_speaker()` do its path resolution explicitly in the function, with safer existing-dir handling
  - replaced the regex-based sentence splitting loop with a linear scanner to address the remaining regex warning