### PR TITLE
Finish CodeQL Path Hardening and Remove Final Speaker/Regex Hotspots

### DIFF
--- a/app/api/routers/voices.py
+++ b/app/api/routers/voices.py
@@ -4,6 +4,7 @@ import time
 import anyio
 import logging
 import re
+import json
 from pathlib import Path
 from typing import Optional, List, Dict
 from fastapi import APIRouter, Depends, Form, File, UploadFile, HTTPException
@@ -110,6 +111,47 @@ def _voice_preview_url(voices_dir: Path, name: str) -> Optional[str]:
     return None
 
 router = APIRouter(tags=["voices"])
+
+
+def _ensure_default_speaker_profile(voices_dir: Path, speaker_id: str, speaker_name: str, default_profile_name: Optional[str]) -> str:
+    profile_name = default_profile_name or speaker_name
+    try:
+        profile_name = _valid_profile_name(profile_name)
+    except ValueError:
+        profile_name = _valid_profile_name(f"speaker-{speaker_id}")
+
+    profile_dir = _existing_voice_profile_dir(voices_dir, profile_name)
+    meta: Dict[str, object] = {}
+
+    if profile_dir:
+        meta_path = _existing_voice_sample_path(voices_dir, profile_name, "profile.json") or (profile_dir / "profile.json")
+        if meta_path.exists():
+            try:
+                meta = json.loads(meta_path.read_text())
+            except Exception:
+                logger.warning("Failed to read existing speaker profile metadata for %s", meta_path, exc_info=True)
+                meta = {}
+
+        if meta.get("speaker_id") and meta["speaker_id"] != speaker_id:
+            idx = 1
+            while _existing_voice_profile_dir(voices_dir, f"{profile_name}_{idx}"):
+                idx += 1
+            profile_name = f"{profile_name}_{idx}"
+            profile_dir = _new_voice_profile_dir(voices_dir, profile_name)
+            meta = {}
+            meta_path = profile_dir / "profile.json"
+    else:
+        profile_dir = _new_voice_profile_dir(voices_dir, profile_name)
+        meta_path = profile_dir / "profile.json"
+
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    meta["speaker_id"] = speaker_id
+    meta["variant_name"] = infer_variant_name(profile_name)
+    if "speed" not in meta:
+        meta["speed"] = 1.0
+    meta_path.write_text(json.dumps(meta, indent=2))
+
+    return profile_name
 
 @router.get("/api/speaker-profiles")
 def list_speaker_profiles(voices_dir: Path = Depends(get_voices_dir)):
@@ -230,6 +272,9 @@ def api_list_speakers_route():
 @router.post("/api/speakers")
 def api_create_speaker_route(name: str = Form(...), default_profile_name: Optional[str] = Form(None)):
     sid = create_speaker(name, default_profile_name)
+    linked_profile_name = _ensure_default_speaker_profile(VOICES_DIR, sid, name, default_profile_name)
+    if linked_profile_name != default_profile_name:
+        update_speaker(sid, default_profile_name=linked_profile_name)
     return JSONResponse({"status": "ok", "id": sid, "speaker_id": sid})
 
 def _rename_profile_folders(old_name: str, new_name: str, voices_dir: Path):

--- a/app/db/speakers.py
+++ b/app/db/speakers.py
@@ -117,9 +117,6 @@ def normalize_base_profiles() -> None:
                 conn.commit()
 
 def create_speaker(name: str, default_profile_name: Optional[str] = None) -> str:
-    import json
-    from .. import config
-
     with _db_lock:
         with get_connection() as conn:
             cursor = conn.cursor()
@@ -130,67 +127,6 @@ def create_speaker(name: str, default_profile_name: Optional[str] = None) -> str
                 VALUES (?, ?, ?, ?, ?)
             """, (speaker_id, name, default_profile_name, now, now))
             conn.commit()
-
-            voices_root = os.path.abspath(os.path.normpath(os.fspath(config.VOICES_DIR.resolve())))
-            existing_dirs: dict[str, Path] = {}
-            if config.VOICES_DIR.exists():
-                try:
-                    for entry in config.VOICES_DIR.iterdir():
-                        if entry.is_dir():
-                            existing_dirs[entry.name] = entry.resolve()
-                except OSError:
-                    existing_dirs = {}
-
-            # Legacy sync: ensure profile directory exists and linked
-            pname = default_profile_name or name
-            try:
-                pname = _profile_name_or_error(pname)
-            except ValueError:
-                pname = f"speaker-{speaker_id}"
-
-            profile_dir = existing_dirs.get(pname)
-            if not profile_dir:
-                profile_path = os.path.abspath(os.path.normpath(os.path.join(voices_root, pname)))
-                if not profile_path.startswith(voices_root + os.sep) and profile_path != voices_root:
-                    raise ValueError(f"Invalid profile directory for {pname}")
-                profile_dir = Path(profile_path)
-
-            # Collision handling: if directory belongs to ANOTHER speaker, use a suffix
-            if profile_dir.exists():
-                meta_path = profile_dir / "profile.json"
-                if meta_path.exists():
-                    try:
-                        existing_meta = json.loads(meta_path.read_text())
-                        if "speaker_id" in existing_meta and existing_meta["speaker_id"] != speaker_id:
-                            # Suffix logic
-                            idx = 1
-                            while f"{pname}_{idx}" in existing_dirs:
-                                idx += 1
-                            pname = f"{pname}_{idx}"
-                            profile_path = os.path.abspath(os.path.normpath(os.path.join(voices_root, pname)))
-                            if not profile_path.startswith(voices_root + os.sep) and profile_path != voices_root:
-                                raise ValueError(f"Invalid profile directory for {pname}")
-                            profile_dir = Path(profile_path)
-                    except Exception:
-                        logger.debug("Failed to inspect existing voice profile metadata for %s", profile_dir, exc_info=True)
-
-            profile_dir.mkdir(parents=True, exist_ok=True)
-
-            meta_path = profile_dir / "profile.json"
-            meta = {}
-            if meta_path.exists():
-                try:
-                    meta = json.loads(meta_path.read_text())
-                except Exception:
-                    logger.debug("Failed to read existing profile metadata for %s", meta_path, exc_info=True)
-
-            meta["speaker_id"] = speaker_id
-            meta["variant_name"] = infer_variant_name(pname)
-            if "speed" not in meta:
-                meta["speed"] = 1.0
-
-            meta_path.write_text(json.dumps(meta, indent=2))
-
             return speaker_id
 
 def get_speaker(speaker_id: str) -> Optional[Dict[str, Any]]:

--- a/tests/test_db_speakers.py
+++ b/tests/test_db_speakers.py
@@ -28,51 +28,32 @@ def db_conn():
         os.unlink(db_path)
 
 def test_speaker_crud(db_conn):
-    # Mock filesystem for legacy sync
-    mock_voices_dir = Path("/tmp/mock_voices")
-    with patch("app.config.VOICES_DIR", mock_voices_dir), \
-         patch("pathlib.Path.mkdir"), \
-         patch("pathlib.Path.write_text"), \
-         patch("pathlib.Path.exists", return_value=False):
+    sid = create_speaker("Narrator 1", "narrator_v1")
+    assert sid is not None
 
-        # Create
-        sid = create_speaker("Narrator 1", "narrator_v1")
-        assert sid is not None
+    speaker = get_speaker(sid)
+    assert speaker is not None
+    assert speaker["name"] == "Narrator 1"
+    assert speaker["default_profile_name"] == "narrator_v1"
 
-        # Get
-        speaker = get_speaker(sid)
-        assert speaker is not None
-        assert speaker["name"] == "Narrator 1"
-        assert speaker["default_profile_name"] == "narrator_v1"
+    speakers = list_speakers()
+    assert len(speakers) == 1
+    assert speakers[0]["id"] == sid
 
-        # List
-        speakers = list_speakers()
-        assert len(speakers) == 1
-        assert speakers[0]["id"] == sid
+    success = update_speaker(sid, name="Old Narrator")
+    assert success is True
+    assert get_speaker(sid)["name"] == "Old Narrator"
 
-        # Update
-        success = update_speaker(sid, name="Old Narrator")
-        assert success is True
-        assert get_speaker(sid)["name"] == "Old Narrator"
-
-        # Delete
-        success = delete_speaker(sid)
-        assert success is True
-        assert get_speaker(sid) is None
+    success = delete_speaker(sid)
+    assert success is True
+    assert get_speaker(sid) is None
 
 def test_speaker_collision_handling(db_conn):
-    mock_voices_dir = Path("/tmp/mock_voices")
-    # Simulate existing profile.json with DIFFERENT speaker_id
-    with patch("app.config.VOICES_DIR", mock_voices_dir), \
-         patch("pathlib.Path.mkdir"), \
-         patch("pathlib.Path.write_text"), \
-         patch("pathlib.Path.exists", side_effect=[True, True, False, True, True, True]), \
-         patch("pathlib.Path.read_text", return_value=json.dumps({"speaker_id": "other-id"})):
-
-        sid = create_speaker("Narrator 1")
-        assert sid is not None
-        # Should have handled collision by creating Narrator 1_1 or similar 
-        # (verification here is tricky without checking internal state or mocks)
+    sid = create_speaker("Narrator 1")
+    assert sid is not None
+    speaker = get_speaker(sid)
+    assert speaker is not None
+    assert speaker["name"] == "Narrator 1"
 
 def test_update_voice_profile_references(db_conn):
     from app.db.projects import create_project

--- a/tests/test_db_speakers_extended.py
+++ b/tests/test_db_speakers_extended.py
@@ -16,14 +16,12 @@ def test_create_speaker_with_collision():
     sid = create_speaker(collision_name)
     assert sid is not None
 
-    # It should have created a suffix directory
-    suffix_dir = config.VOICES_DIR / f"{collision_name}_1"
-    assert suffix_dir.exists()
-    assert (suffix_dir / "profile.json").exists()
+    # Speaker creation is DB-only; the existing profile directory should remain untouched
+    assert profile_dir.exists()
+    assert json.loads((profile_dir / "profile.json").read_text())["speaker_id"] == "other-id"
 
     # Clean up
     shutil.rmtree(profile_dir)
-    shutil.rmtree(suffix_dir)
 
 def test_get_speaker():
     sid = create_speaker("Get Speaker Test")


### PR DESCRIPTION
## Summary

This PR continues the CodeQL cleanup and reduces the remaining code scanning issues down to a very small final cluster by tightening path handling in the last high-noise areas.

The main focus of this pass was:
- eliminating more `py/path-injection` findings
- shifting project/audio lookups toward trusted existing-directory enumeration
- removing filesystem side effects from the database speaker creation path
- preserving the app’s existing voice-profile behavior in the API layer
- replacing the remaining regex shape that was vulnerable to polynomial backtracking

## What Changed

### Project and Audio Path Hardening
- Added existing project lookup helpers in `app/config.py`
- Refined project subdirectory handling so we prefer already-existing trusted directories instead of fabricating paths during read/check flows
- Updated the remaining chapter/audio and audiobook-related paths to use existing directory enumeration where possible

Files touched:
- `app/config.py`
- `app/db/reconcile.py`
- `app/db/chapters.py`
- `app/api/routers/settings.py`
- `app/api/routers/projects.py`
- `app/api/routers/generation.py`
- `app/api/routers/chapters.py`

### Speaker Path Cleanup
- Removed filesystem writes from `app/db/speakers.py:create_speaker`
- Moved the “auto-link existing profile / create default profile / collision suffix” behavior into the voices API layer, where it can use the existing trusted voice-directory helpers
- Preserved the existing product behavior for speaker creation while removing the DB-layer path-writing pattern that CodeQL was still flagging

Files touched:
- `app/db/speakers.py`
- `app/api/routers/voices.py`

### Regex Safety
- Replaced the sentence-splitting regex loop in `app/textops.py` with a linear scanner
- This keeps sentence splitting behavior while avoiding the remaining regex complexity warning pattern

Files touched:
- `app/textops.py`

### Compatibility Cleanup
- Updated the legacy audiobook wrapper to match the refactored system route signature
- Adjusted tests to patch the new trusted lookup seams instead of the older project-audio helper path

Files touched:
- `app/web.py`
- `tests/test_api_generation.py`
- `tests/test_db_chapters.py`
- `tests/test_db_reconcile.py`
- `tests/test_db_speakers.py`
- `tests/test_db_speakers_extended.py`

## Why This Matters

The remaining alerts were no longer broad; they were concentrated in a few stubborn path-construction flows. This PR focuses on those directly and keeps the code moving toward a clearer model:

- use trusted existing directories/files where possible
- avoid DB-layer path writes from user-controlled names
- keep path creation logic in the higher-level workflow that actually owns that behavior
- remove regex constructs that static analysis reasonably dislikes

## Verification

## Notes

The previous scan had already reduced the count significantly. This PR is intended to clear or heavily reduce the final path-injection cluster that was left in `app/db/speakers.py`, along with the last regex warning that was addressed in `app/textops.py`.
