### PR TITLE
Stabilize Voices Path Hardening and Restore API/Test Compatibility

### DIFF
--- a/app/api/routers/system.py
+++ b/app/api/routers/system.py
@@ -59,7 +59,7 @@ def api_home(
     """Returns initial data for the React SPA."""
     from .voices import list_speaker_profiles
 
-    profiles = list_speaker_profiles(voices_dir=voices_dir)
+    profiles = list_speaker_profiles()
     speakers = list_speakers()
     settings = get_settings()
     jobs = {j_id: job for j_id, job in get_jobs().items()}

--- a/app/api/routers/voices.py
+++ b/app/api/routers/voices.py
@@ -7,7 +7,7 @@ import re
 import json
 from pathlib import Path
 from typing import Optional, List, Dict
-from fastapi import APIRouter, Depends, Form, File, UploadFile, HTTPException
+from fastapi import APIRouter, Form, File, UploadFile, HTTPException
 from fastapi.responses import JSONResponse
 from ...db import (
     get_characters, create_character, update_character, delete_character,
@@ -48,22 +48,22 @@ def _valid_sample_name(sample_name: str) -> str:
     return sample_name
 
 
-def _voice_dirs_map(voices_dir: Path) -> Dict[str, Path]:
-    if not voices_dir.exists():
+def _voice_dirs_map() -> Dict[str, Path]:
+    if not VOICES_DIR.exists():
         return {}
     dirs: Dict[str, Path] = {}
-    for entry in voices_dir.iterdir():
+    for entry in VOICES_DIR.iterdir():
         if entry.is_dir() and SAFE_PROFILE_NAME_RE.fullmatch(entry.name):
             dirs[entry.name] = entry.resolve()
     return dirs
 
 
-def _existing_voice_profile_dir(voices_dir: Path, name: str) -> Optional[Path]:
-    return _voice_dirs_map(voices_dir).get(_valid_profile_name(name))
+def _existing_voice_profile_dir(name: str) -> Optional[Path]:
+    return _voice_dirs_map().get(_valid_profile_name(name))
 
 
-def _new_voice_profile_dir(voices_dir: Path, name: str) -> Path:
-    return voices_dir / _valid_profile_name(name)
+def _new_voice_profile_dir(name: str) -> Path:
+    return VOICES_DIR / _valid_profile_name(name)
 
 
 def _voice_file_map(profile_dir: Optional[Path]) -> Dict[str, Path]:
@@ -76,17 +76,17 @@ def _voice_file_map(profile_dir: Optional[Path]) -> Dict[str, Path]:
     return files
 
 
-def _existing_voice_sample_path(voices_dir: Path, name: str, sample_name: str) -> Optional[Path]:
-    return _voice_file_map(_existing_voice_profile_dir(voices_dir, name)).get(_valid_sample_name(sample_name))
+def _existing_voice_sample_path(name: str, sample_name: str) -> Optional[Path]:
+    return _voice_file_map(_existing_voice_profile_dir(name)).get(_valid_sample_name(sample_name))
 
 
 def _new_voice_sample_path(profile_dir: Path, sample_name: str) -> Path:
     return profile_dir / _valid_sample_name(sample_name)
 
 
-def _voice_raw_sample_count(voices_dir: Path, name: str) -> int:
+def _voice_raw_sample_count(name: str) -> int:
     try:
-        profile_dir = _existing_voice_profile_dir(voices_dir, name)
+        profile_dir = _existing_voice_profile_dir(name)
     except ValueError:
         return 0
     if not profile_dir:
@@ -97,8 +97,8 @@ def _voice_raw_sample_count(voices_dir: Path, name: str) -> int:
     ])
 
 
-def _voice_preview_url(voices_dir: Path, name: str) -> Optional[str]:
-    profile_dir = _existing_voice_profile_dir(voices_dir, name)
+def _voice_preview_url(name: str) -> Optional[str]:
+    profile_dir = _existing_voice_profile_dir(name)
     if not profile_dir:
         return None
     files = _voice_file_map(profile_dir)
@@ -113,18 +113,18 @@ def _voice_preview_url(voices_dir: Path, name: str) -> Optional[str]:
 router = APIRouter(tags=["voices"])
 
 
-def _ensure_default_speaker_profile(voices_dir: Path, speaker_id: str, speaker_name: str, default_profile_name: Optional[str]) -> str:
+def _ensure_default_speaker_profile(speaker_id: str, speaker_name: str, default_profile_name: Optional[str]) -> str:
     profile_name = default_profile_name or speaker_name
     try:
         profile_name = _valid_profile_name(profile_name)
     except ValueError:
         profile_name = _valid_profile_name(f"speaker-{speaker_id}")
 
-    profile_dir = _existing_voice_profile_dir(voices_dir, profile_name)
+    profile_dir = _existing_voice_profile_dir(profile_name)
     meta: Dict[str, object] = {}
 
     if profile_dir:
-        meta_path = _existing_voice_sample_path(voices_dir, profile_name, "profile.json") or (profile_dir / "profile.json")
+        meta_path = _existing_voice_sample_path(profile_name, "profile.json") or (profile_dir / "profile.json")
         if meta_path.exists():
             try:
                 meta = json.loads(meta_path.read_text())
@@ -134,14 +134,14 @@ def _ensure_default_speaker_profile(voices_dir: Path, speaker_id: str, speaker_n
 
         if meta.get("speaker_id") and meta["speaker_id"] != speaker_id:
             idx = 1
-            while _existing_voice_profile_dir(voices_dir, f"{profile_name}_{idx}"):
+            while _existing_voice_profile_dir(f"{profile_name}_{idx}"):
                 idx += 1
             profile_name = f"{profile_name}_{idx}"
-            profile_dir = _new_voice_profile_dir(voices_dir, profile_name)
+            profile_dir = _new_voice_profile_dir(profile_name)
             meta = {}
             meta_path = profile_dir / "profile.json"
     else:
-        profile_dir = _new_voice_profile_dir(voices_dir, profile_name)
+        profile_dir = _new_voice_profile_dir(profile_name)
         meta_path = profile_dir / "profile.json"
 
     profile_dir.mkdir(parents=True, exist_ok=True)
@@ -154,11 +154,11 @@ def _ensure_default_speaker_profile(voices_dir: Path, speaker_id: str, speaker_n
     return profile_name
 
 @router.get("/api/speaker-profiles")
-def list_speaker_profiles(voices_dir: Path = Depends(get_voices_dir)):
-    if not voices_dir.exists():
+def list_speaker_profiles():
+    if not VOICES_DIR.exists():
         return []
 
-    dirs = [path for _, path in sorted(_voice_dirs_map(voices_dir).items(), key=lambda item: item[0])]
+    dirs = [path for _, path in sorted(_voice_dirs_map().items(), key=lambda item: item[0])]
     settings = get_settings()
     default_speaker = settings.get("default_speaker_profile")
 
@@ -188,7 +188,7 @@ def list_speaker_profiles(voices_dir: Path = Depends(get_voices_dir)):
         if len([b for b in built_samples if SAFE_SAMPLE_NAME_RE.fullmatch(b) and (d / b).exists()]) < len(built_samples):
              is_rebuild_required = True
 
-        preview_url = _voice_preview_url(voices_dir, d.name)
+        preview_url = _voice_preview_url(d.name)
         if not preview_url and len(raw_wavs) > 0:
             is_rebuild_required = True
 
@@ -211,7 +211,6 @@ def list_speaker_profiles(voices_dir: Path = Depends(get_voices_dir)):
 def api_create_speaker_profile(
     speaker_id: str = Form(...),
     variant_name: str = Form(...),
-    voices_dir: Path = Depends(get_voices_dir)
 ):
     logger.info(f"Creating profile for speaker_id='{speaker_id}', variant_name='{variant_name}'")
     try:
@@ -221,7 +220,7 @@ def api_create_speaker_profile(
         name = f"{spk_name} - {variant_name}"
         # Constructed path
         try:
-            path = _existing_voice_profile_dir(voices_dir, name) or _new_voice_profile_dir(voices_dir, name)
+            path = _existing_voice_profile_dir(name) or _new_voice_profile_dir(name)
         except ValueError:
             logger.warning(f"Blocking profile creation traversal attempt: {name}")
             return JSONResponse({"status": "error", "message": "Invalid profile name"}, status_code=403)
@@ -272,17 +271,17 @@ def api_list_speakers_route():
 @router.post("/api/speakers")
 def api_create_speaker_route(name: str = Form(...), default_profile_name: Optional[str] = Form(None)):
     sid = create_speaker(name, default_profile_name)
-    linked_profile_name = _ensure_default_speaker_profile(VOICES_DIR, sid, name, default_profile_name)
+    linked_profile_name = _ensure_default_speaker_profile(sid, name, default_profile_name)
     if linked_profile_name != default_profile_name:
         update_speaker(sid, default_profile_name=linked_profile_name)
     return JSONResponse({"status": "ok", "id": sid, "speaker_id": sid})
 
-def _rename_profile_folders(old_name: str, new_name: str, voices_dir: Path):
+def _rename_profile_folders(old_name: str, new_name: str):
     """Helper to rename all profile folders on disk starting with a speaker name."""
     try:
-        voice_dirs = _voice_dirs_map(voices_dir)
+        voice_dirs = _voice_dirs_map()
         old_dir = voice_dirs.get(_valid_profile_name(old_name))
-        new_dir = voice_dirs.get(_valid_profile_name(new_name)) or _new_voice_profile_dir(voices_dir, new_name)
+        new_dir = voice_dirs.get(_valid_profile_name(new_name)) or _new_voice_profile_dir(new_name)
     except ValueError:
         logger.warning(f"Blocking profile rename traversal attempt: {old_name} -> {new_name}")
         raise HTTPException(status_code=403, detail="Invalid profile name")
@@ -292,7 +291,7 @@ def _rename_profile_folders(old_name: str, new_name: str, voices_dir: Path):
         old_dir.rename(new_dir)
         update_voice_profile_references(old_name, new_name)
         # Update meta if exists
-        meta_path = _existing_voice_sample_path(voices_dir, new_name, "profile.json")
+        meta_path = _existing_voice_sample_path(new_name, "profile.json")
         if meta_path:
             try:
                 import json
@@ -308,18 +307,18 @@ def _rename_profile_folders(old_name: str, new_name: str, voices_dir: Path):
 
     # 2. Variants (Narrator - Variant)
     variants = []
-    for dir_name, d in _voice_dirs_map(voices_dir).items():
+    for dir_name, d in _voice_dirs_map().items():
         if dir_name.startswith(old_name + " - "):
             variants.append(d)
     for vdir in variants:
         suffix = vdir.name[len(old_name):]
         new_vname = new_name + suffix
-        new_vpath = _existing_voice_profile_dir(voices_dir, new_vname) or _new_voice_profile_dir(voices_dir, new_vname)
+        new_vpath = _existing_voice_profile_dir(new_vname) or _new_voice_profile_dir(new_vname)
         if not new_vpath.exists():
             vdir.rename(new_vpath)
             update_voice_profile_references(vdir.name, new_vname)
             # Update meta
-            meta_path = _existing_voice_sample_path(voices_dir, new_vname, "profile.json")
+            meta_path = _existing_voice_sample_path(new_vname, "profile.json")
             if meta_path:
                 try:
                     import json
@@ -339,7 +338,6 @@ def api_update_speaker_route(
     name: Optional[str] = Form(None), 
     new_name: Optional[str] = Form(None), # Alias for name
     default_profile_name: Optional[str] = Form(None),
-    voices_dir: Path = Depends(get_voices_dir)
 ):
     from ...db.speakers import get_speaker
     old_spk = get_speaker(speaker_id)
@@ -355,7 +353,7 @@ def api_update_speaker_route(
 
     if target_name and target_name != old_spk["name"]:
         # Renaming narrator: rename all profile directories on disk
-        _rename_profile_folders(old_spk["name"], target_name, voices_dir)
+        _rename_profile_folders(old_spk["name"], target_name)
 
     return JSONResponse({"status": "ok"})
 
@@ -368,7 +366,6 @@ def api_delete_speaker_route(speaker_id: str):
 def api_assign_profile_to_speaker(
     profile_name: str,
     speaker_id: Optional[str] = Form(None),
-    voices_dir: Path = Depends(get_voices_dir)
 ):
     """Reassign a variant profile to a different speaker (or unassign it).
     This renames the folder to match the new speaker's naming, and updates profile.json.
@@ -376,7 +373,7 @@ def api_assign_profile_to_speaker(
     import json as _json
     try:
         try:
-            old_dir = _existing_voice_profile_dir(voices_dir, profile_name)
+            old_dir = _existing_voice_profile_dir(profile_name)
         except ValueError:
             return JSONResponse({"status": "error", "message": "Invalid profile name"}, status_code=403)
         if not old_dir:
@@ -384,7 +381,7 @@ def api_assign_profile_to_speaker(
 
         # Determine the variant name from existing metadata or folder name
         variant_name = None
-        meta_path = _existing_voice_sample_path(voices_dir, profile_name, "profile.json")
+        meta_path = _existing_voice_sample_path(profile_name, "profile.json")
         meta = {}
         if meta_path:
             try:
@@ -407,7 +404,7 @@ def api_assign_profile_to_speaker(
             new_profile_name = variant_name
 
         try:
-            new_dir = _existing_voice_profile_dir(voices_dir, new_profile_name) or _new_voice_profile_dir(voices_dir, new_profile_name)
+            new_dir = _existing_voice_profile_dir(new_profile_name) or _new_voice_profile_dir(new_profile_name)
         except ValueError:
             return JSONResponse({"status": "error", "message": "Invalid target profile name"}, status_code=403)
 
@@ -420,7 +417,7 @@ def api_assign_profile_to_speaker(
             update_voice_profile_references(profile_name, new_profile_name)
 
         # Update profile.json with new speaker_id and variant_name
-        new_meta_path = _existing_voice_sample_path(voices_dir, new_profile_name, "profile.json") or (new_dir / "profile.json")
+        new_meta_path = _existing_voice_sample_path(new_profile_name, "profile.json") or (new_dir / "profile.json")
         meta.update({"speaker_id": speaker_id, "variant_name": variant_name})
         normalized_meta = normalize_profile_metadata(new_profile_name, meta, persist=False)
         new_meta_path.write_text(_json.dumps(normalized_meta, indent=2))
@@ -434,10 +431,9 @@ def api_assign_profile_to_speaker(
 def api_rename_voice_profile(
     old_name: str = Form(...),
     new_name: str = Form(...),
-    voices_dir: Path = Depends(get_voices_dir)
 ):
     try:
-        _rename_profile_folders(old_name, new_name, voices_dir)
+        _rename_profile_folders(old_name, new_name)
 
         # Sync global settings
         settings = get_settings()
@@ -470,16 +466,15 @@ def update_speaker_speed(name: str, speed: float = Form(...)):
 async def build_speaker_profile(
     name: str,
     files: List[UploadFile] = File(default=[]),
-    voices_dir: Path = Depends(get_voices_dir)
 ):
     try:
         try:
-            path = _existing_voice_profile_dir(voices_dir, name) or _new_voice_profile_dir(voices_dir, name)
+            path = _existing_voice_profile_dir(name) or _new_voice_profile_dir(name)
         except ValueError:
             logger.warning(f"Blocking profile build traversal attempt: {name}")
             return JSONResponse({"status": "error", "message": "Invalid profile name"}, status_code=403)
 
-        existing_raw_samples = _voice_raw_sample_count(voices_dir, name)
+        existing_raw_samples = _voice_raw_sample_count(name)
         if existing_raw_samples == 0 and not files:
             return JSONResponse(
                 {"status": "error", "message": "Add at least one sample before building this voice."},
@@ -489,7 +484,7 @@ async def build_speaker_profile(
         path.mkdir(parents=True, exist_ok=True)
 
         # Clear existing sample if it exists to ensure accurate building status
-        sample_path = _existing_voice_sample_path(voices_dir, name, "sample.wav")
+        sample_path = _existing_voice_sample_path(name, "sample.wav")
         if sample_path:
             sample_path.unlink()
     except Exception as e:
@@ -531,11 +526,10 @@ async def build_speaker_profile(
 async def upload_speaker_samples(
     name: str,
     files: List[UploadFile] = File(...),
-    voices_dir: Path = Depends(get_voices_dir)
 ):
     try:
         try:
-            path = _existing_voice_profile_dir(voices_dir, name) or _new_voice_profile_dir(voices_dir, name)
+            path = _existing_voice_profile_dir(name) or _new_voice_profile_dir(name)
         except ValueError:
             return JSONResponse({"status": "error", "message": "Invalid profile"}, status_code=403)
 
@@ -559,11 +553,10 @@ async def upload_speaker_samples(
 def delete_speaker_sample(
     name: str,
     sample_name: str,
-    voices_dir: Path = Depends(get_voices_dir)
 ):
     try:
         try:
-            path = _existing_voice_sample_path(voices_dir, name, sample_name)
+            path = _existing_voice_sample_path(name, sample_name)
         except ValueError:
             return JSONResponse({"status": "error", "message": "Invalid path"}, status_code=403)
 
@@ -579,28 +572,25 @@ def delete_speaker_sample(
 def api_rename_voice_profile_path(
     name: str,
     new_name: str = Form(...),
-    voices_dir: Path = Depends(get_voices_dir)
 ):
     return api_rename_voice_profile(
         old_name=name,
         new_name=new_name,
-        voices_dir=voices_dir
     )
 
 @router.delete("/api/speaker-profiles/{name}")
 def delete_speaker_profile(
     name: str,
-    voices_dir: Path = Depends(get_voices_dir)
 ):
     try:
         try:
-            path = _existing_voice_profile_dir(voices_dir, name)
+            path = _existing_voice_profile_dir(name)
         except ValueError:
             logger.warning(f"Blocking profile delete traversal attempt: {name}")
             return JSONResponse({"status": "error", "message": "Invalid profile name"}, status_code=403)
 
         if path:
-            if path.is_relative_to(voices_dir.resolve()):
+            if path.is_relative_to(VOICES_DIR.resolve()):
                 shutil.rmtree(path)
             else:
                 logger.warning("Blocking profile delete outside voices root: %s", path)
@@ -613,8 +603,8 @@ def delete_speaker_profile(
     return JSONResponse({"status": "error", "message": "Not found"}, status_code=404)
 
 @router.post("/api/speaker-profiles/{name}/test")
-def test_speaker_profile(name: str, voices_dir: Path = Depends(get_voices_dir)):
-    if _voice_raw_sample_count(voices_dir, name) == 0:
+def test_speaker_profile(name: str):
+    if _voice_raw_sample_count(name) == 0:
         return JSONResponse(
             {"status": "error", "message": "Add at least one sample before testing this voice."},
             status_code=400
@@ -631,7 +621,7 @@ def test_speaker_profile(name: str, voices_dir: Path = Depends(get_voices_dir)):
     )
     put_job(j)
     enqueue(j)
-    preview_url = _voice_preview_url(voices_dir, name)
+    preview_url = _voice_preview_url(name)
     return JSONResponse({
         "status": "ok", 
         "job_id": jid,

--- a/tests/test_api_voices.py
+++ b/tests/test_api_voices.py
@@ -7,6 +7,22 @@ from pathlib import Path
 from unittest.mock import patch, MagicMock
 from app.db.core import init_db
 
+
+@pytest.fixture(autouse=True)
+def voices_root(tmp_path, monkeypatch):
+    import app.config
+    import app.web
+    import app.api.routers.voices
+    import app.jobs.speaker
+
+    voices_dir = (tmp_path / "voices").resolve()
+    monkeypatch.setattr(app.web, "VOICES_DIR", voices_dir)
+    monkeypatch.setattr(app.config, "VOICES_DIR", voices_dir)
+    monkeypatch.setattr(app.api.routers.voices, "VOICES_DIR", voices_dir)
+    monkeypatch.setattr(app.jobs.speaker, "VOICES_DIR", voices_dir)
+    return voices_dir
+
+
 @pytest.fixture
 def client():
     from fastapi.testclient import TestClient
@@ -14,7 +30,7 @@ def client():
     return TestClient(fastapi_app)
 
 @pytest.fixture
-def clean_db():
+def clean_db(tmp_path):
     from app.web import app as fastapi_app
     db_path = "/tmp/test_api_voices.db"
     if os.path.exists(db_path):
@@ -31,15 +47,11 @@ def clean_db():
         os.unlink(db_path)
     fastapi_app.dependency_overrides = {}
 
-def test_list_speaker_profiles(clean_db, tmp_path, client):
-    from app.web import app as fastapi_app
-    from app.api.routers.voices import get_voices_dir
-    voices_dir = tmp_path / "voices"
+def test_list_speaker_profiles(clean_db, voices_root, client):
+    voices_dir = voices_root
     voices_dir.mkdir()
     (voices_dir / "SpeakerA").mkdir()
     (voices_dir / "SpeakerA" / "v1.wav").write_text("audio")
-
-    fastapi_app.dependency_overrides[get_voices_dir] = lambda: voices_dir
 
     with patch("app.api.routers.voices.get_speaker_settings", return_value={"built_samples": [], "speed": 1.0, "test_text": ""}):
         response = client.get("/api/speaker-profiles")
@@ -48,12 +60,9 @@ def test_list_speaker_profiles(clean_db, tmp_path, client):
         assert len(data) == 1
         assert data[0]["name"] == "SpeakerA"
 
-def test_create_and_delete_profile(clean_db, tmp_path, client):
-    from app.web import app as fastapi_app
-    from app.api.routers.voices import get_voices_dir
-    voices_dir = (tmp_path / "voices").resolve()
+def test_create_and_delete_profile(clean_db, voices_root, client):
+    voices_dir = voices_root
     voices_dir.mkdir()
-    fastapi_app.dependency_overrides[get_voices_dir] = lambda: voices_dir
 
     # Create
     response = client.post("/api/speaker-profiles", data={"speaker_id": "S1", "variant_name": "V1"})
@@ -107,16 +116,12 @@ def test_speaker_crud(clean_db, client):
     response = client.delete(f"/api/speakers/{sid}")
     assert response.status_code == 200
 
-def test_rename_profile_and_security(clean_db, tmp_path, client):
-    from app.web import app as fastapi_app
-    from app.api.routers.voices import get_voices_dir
-    voices_dir = (tmp_path / "voices").resolve()
+def test_rename_profile_and_security(clean_db, voices_root, client):
+    voices_dir = voices_root
     voices_dir.mkdir()
     (voices_dir / "OldName").mkdir()
     (voices_dir / "OldName" / "profile.json").write_text(json.dumps({"variant_name": "Old"}))
     (voices_dir / "OldName" / "latent.pth").write_text("latent")
-
-    fastapi_app.dependency_overrides[get_voices_dir] = lambda: voices_dir
 
     # Success
     response = client.post("/api/voices/rename-profile", data={"old_name": "OldName", "new_name": "NewName - Variant"})
@@ -143,16 +148,14 @@ def test_speaker_settings_updates(clean_db, client):
 
     assert mock_update.call_count == 2
 
-def test_reset_speaker_test_text(clean_db, tmp_path, client):
-    from app.web import app as fastapi_app
-    from app.api.routers.voices import get_voices_dir, DEFAULT_SPEAKER_TEST_TEXT
+def test_reset_speaker_test_text(clean_db, voices_root, client):
+    from app.api.routers.voices import DEFAULT_SPEAKER_TEST_TEXT
 
-    voices_dir = (tmp_path / "voices").resolve()
+    voices_dir = voices_root
     profile_dir = voices_dir / "SpeakerA"
     profile_dir.mkdir(parents=True)
     (profile_dir / "profile.json").write_text(json.dumps({"test_text": "Custom text"}))
 
-    fastapi_app.dependency_overrides[get_voices_dir] = lambda: voices_dir
     with patch("app.jobs.speaker.VOICES_DIR", voices_dir):
         response = client.post("/api/speaker-profiles/SpeakerA/reset-test-text")
 
@@ -160,12 +163,9 @@ def test_reset_speaker_test_text(clean_db, tmp_path, client):
     assert response.json()["test_text"] == DEFAULT_SPEAKER_TEST_TEXT
     assert "test_text" not in json.loads((profile_dir / "profile.json").read_text())
 
-def test_build_and_test_profiles(clean_db, tmp_path, client):
-    from app.web import app as fastapi_app
-    from app.api.routers.voices import get_voices_dir
-    voices_dir = (tmp_path / "voices").resolve()
+def test_build_and_test_profiles(clean_db, voices_root, client):
+    voices_dir = voices_root
     voices_dir.mkdir()
-    fastapi_app.dependency_overrides[get_voices_dir] = lambda: voices_dir
 
     with patch("app.api.routers.voices.VOICES_DIR", voices_dir):
         # Build
@@ -183,12 +183,9 @@ def test_build_and_test_profiles(clean_db, tmp_path, client):
             response = client.post("/api/speaker-profiles/SpeakerA/test")
             assert response.status_code == 200
 
-def test_build_and_test_require_samples(clean_db, tmp_path, client):
-    from app.web import app as fastapi_app
-    from app.api.routers.voices import get_voices_dir
-    voices_dir = (tmp_path / "voices").resolve()
+def test_build_and_test_require_samples(clean_db, voices_root, client):
+    voices_dir = voices_root
     voices_dir.mkdir()
-    fastapi_app.dependency_overrides[get_voices_dir] = lambda: voices_dir
 
     with patch("app.api.routers.voices.VOICES_DIR", voices_dir):
         profile_dir = voices_dir / "SpeakerA"
@@ -203,12 +200,9 @@ def test_build_and_test_require_samples(clean_db, tmp_path, client):
             assert response.status_code == 400
             assert "sample" in response.json()["message"].lower()
 
-def test_legacy_build_and_rename(clean_db, tmp_path, client):
-    from app.web import app as fastapi_app
-    from app.api.routers.voices import get_voices_dir
-    voices_dir = (tmp_path / "voices").resolve()
+def test_legacy_build_and_rename(clean_db, voices_root, client):
+    voices_dir = voices_root
     voices_dir.mkdir()
-    fastapi_app.dependency_overrides[get_voices_dir] = lambda: voices_dir
 
     # Legacy Build
     with patch("app.api.routers.voices.put_job"), patch("app.api.routers.voices.enqueue"):
@@ -221,12 +215,9 @@ def test_legacy_build_and_rename(clean_db, tmp_path, client):
     response = client.post("/api/speaker-profiles/SpeakerL/rename", data={"new_name": "SpeakerNew"})
     assert response.status_code == 200
 
-def test_profile_creation_errors(clean_db, tmp_path, client):
-    from app.web import app as fastapi_app
-    from app.api.routers.voices import get_voices_dir
-    voices_dir = (tmp_path / "voices").resolve()
+def test_profile_creation_errors(clean_db, voices_root, client):
+    voices_dir = voices_root
     voices_dir.mkdir()
-    fastapi_app.dependency_overrides[get_voices_dir] = lambda: voices_dir
 
     # Already exists
     (voices_dir / "S1 - V1").mkdir()
@@ -242,18 +233,14 @@ def test_profile_creation_errors(clean_db, tmp_path, client):
         response = client.post("/api/speaker-profiles", data={"speaker_id": "Err", "variant_name": "V1"})
         assert response.status_code == 500
 
-def test_rename_speaker_with_variants(clean_db, tmp_path, client):
-    from app.web import app as fastapi_app
-    from app.api.routers.voices import get_voices_dir
-    voices_dir = (tmp_path / "voices").resolve()
+def test_rename_speaker_with_variants(clean_db, voices_root, client):
+    voices_dir = voices_root
     voices_dir.mkdir()
     (voices_dir / "Narrator").mkdir()
     (voices_dir / "Narrator - Calm").mkdir()
     (voices_dir / "Narrator - Calm" / "profile.json").write_text(json.dumps({"speaker_id": "Narrator"}))
     (voices_dir / "Narrator - Calm" / "latent.pth").write_text("latent")
     (voices_dir / "Narrator - Excited").mkdir()
-
-    fastapi_app.dependency_overrides[get_voices_dir] = lambda: voices_dir
 
     # Rename
     response = client.post("/api/voices/rename-profile", data={"old_name": "Narrator", "new_name": "Dracula"})
@@ -271,27 +258,20 @@ def test_rename_speaker_with_variants(clean_db, tmp_path, client):
     meta = json.loads((voices_dir / "Dracula - Calm" / "profile.json").read_text())
     assert meta["speaker_id"] == "Dracula"
 
-def test_rename_profile_default_sync(clean_db, tmp_path, client):
-    from app.web import app as fastapi_app
-    from app.api.routers.voices import get_voices_dir
+def test_rename_profile_default_sync(clean_db, voices_root, client):
     from app.state import update_settings, get_settings
     update_settings({"default_speaker_profile": "OldProfile"})
 
-    voices_dir = (tmp_path / "voices").resolve()
+    voices_dir = voices_root
     voices_dir.mkdir()
     (voices_dir / "OldProfile").mkdir()
-    fastapi_app.dependency_overrides[get_voices_dir] = lambda: voices_dir
-
     response = client.post("/api/voices/rename-profile", data={"old_name": "OldProfile", "new_name": "NewProfile"})
     assert response.status_code == 200
     assert get_settings()["default_speaker_profile"] == "NewProfile"
 
-def test_upload_samples_security_and_failure(clean_db, tmp_path, client):
-    from app.web import app as fastapi_app
-    from app.api.routers.voices import get_voices_dir
-    voices_dir = (tmp_path / "voices").resolve()
+def test_upload_samples_security_and_failure(clean_db, voices_root, client):
+    voices_dir = voices_root
     voices_dir.mkdir()
-    fastapi_app.dependency_overrides[get_voices_dir] = lambda: voices_dir
 
     # Define files for the test
     files = {"files": ("sample.wav", io.BytesIO(b"data"), "audio/wav")}
@@ -301,14 +281,11 @@ def test_upload_samples_security_and_failure(clean_db, tmp_path, client):
         response = client.post("/api/speaker-profiles/SpeakerA/samples/upload", files=files)
         assert response.status_code == 500
 
-def test_delete_sample_errors(clean_db, tmp_path, client):
-    from app.web import app as fastapi_app
-    from app.api.routers.voices import get_voices_dir
-    voices_dir = (tmp_path / "voices").resolve()
+def test_delete_sample_errors(clean_db, voices_root, client):
+    voices_dir = voices_root
     voices_dir.mkdir()
     (voices_dir / "SpeakerA").mkdir()
     (voices_dir / "SpeakerA" / "sample1.wav").write_text("audio")
-    fastapi_app.dependency_overrides[get_voices_dir] = lambda: voices_dir
 
     # Success
     response = client.delete("/api/speaker-profiles/SpeakerA/samples/sample1.wav")
@@ -322,27 +299,23 @@ def test_delete_sample_errors(clean_db, tmp_path, client):
         assert response.status_code == 500
 
 
-def test_delete_sample_rejects_traversal(tmp_path):
+def test_delete_sample_rejects_traversal(voices_root):
     from app.api.routers.voices import delete_speaker_sample
 
-    voices_dir = (tmp_path / "voices").resolve()
+    voices_dir = voices_root
     voices_dir.mkdir()
     (voices_dir / "SpeakerA").mkdir()
-
-    response = delete_speaker_sample(
-        name="SpeakerA",
-        sample_name="../../escape.wav",
-        voices_dir=voices_dir,
-    )
+    with patch("app.api.routers.voices.VOICES_DIR", voices_dir):
+        response = delete_speaker_sample(
+            name="SpeakerA",
+            sample_name="../../escape.wav",
+        )
     assert response.status_code == 403
 
-def test_assign_profile_to_speaker_errors(clean_db, tmp_path, client):
-    from app.web import app as fastapi_app
-    from app.api.routers.voices import get_voices_dir
-    voices_dir = (tmp_path / "voices").resolve()
+def test_assign_profile_to_speaker_errors(clean_db, voices_root, client):
+    voices_dir = voices_root
     voices_dir.mkdir()
     (voices_dir / "SomeProf").mkdir()
-    fastapi_app.dependency_overrides[get_voices_dir] = lambda: voices_dir
 
     # Generic error
     with patch("app.api.routers.voices.get_speaker", side_effect=Exception("db crash")):

--- a/tests/test_speaker_refinement.py
+++ b/tests/test_speaker_refinement.py
@@ -8,19 +8,30 @@ from fastapi.testclient import TestClient
 from app.web import app as fastapi_app
 from app.db.core import init_db
 from app.db.speakers import create_speaker
-from app.api.routers.voices import get_voices_dir
 
 client = TestClient(fastapi_app)
+
+
+@pytest.fixture(autouse=True)
+def voices_root(tmp_path, monkeypatch):
+    import app.config
+    import app.web
+    import app.api.routers.voices
+    import app.jobs.speaker
+
+    voices_dir = (tmp_path / "voices").resolve()
+    monkeypatch.setattr(app.web, "VOICES_DIR", voices_dir)
+    monkeypatch.setattr(app.config, "VOICES_DIR", voices_dir)
+    monkeypatch.setattr(app.api.routers.voices, "VOICES_DIR", voices_dir)
+    monkeypatch.setattr(app.jobs.speaker, "VOICES_DIR", voices_dir)
+    return voices_dir
+
 
 @pytest.fixture
 def clean_db(tmp_path):
     db_path = tmp_path / "test_refinement.db"
     os.environ["DB_PATH"] = str(db_path)
     import app.db.core
-    import app.jobs.speaker
-    import app.api.routers.voices
-    app.jobs.speaker.VOICES_DIR = tmp_path / "voices"
-    app.api.routers.voices.VOICES_DIR = tmp_path / "voices"
     import importlib
     importlib.reload(app.db.core)
     init_db()
@@ -28,10 +39,9 @@ def clean_db(tmp_path):
     if os.path.exists(db_path):
         os.unlink(db_path)
 
-def test_variant_folder_naming(clean_db, tmp_path):
-    voices_dir = tmp_path / "voices"
+def test_variant_folder_naming(clean_db, voices_root):
+    voices_dir = voices_root
     voices_dir.mkdir()
-    fastapi_app.dependency_overrides[get_voices_dir] = lambda: voices_dir
 
     # 1. Create a speaker
     sid = create_speaker("TestSpeaker")
@@ -45,10 +55,9 @@ def test_variant_folder_naming(clean_db, tmp_path):
     assert name == "TestSpeaker - Variant1"
     assert (voices_dir / "TestSpeaker - Variant1").exists()
 
-def test_rename_unassigned_profile(clean_db, tmp_path):
-    voices_dir = tmp_path / "voices"
+def test_rename_unassigned_profile(clean_db, voices_root):
+    voices_dir = voices_root
     voices_dir.mkdir()
-    fastapi_app.dependency_overrides[get_voices_dir] = lambda: voices_dir
 
     # 1. Create a profile folder manually (unassigned)
     profile_path = voices_dir / "OldUnassigned"
@@ -63,10 +72,9 @@ def test_rename_unassigned_profile(clean_db, tmp_path):
     assert (voices_dir / "NewUnassigned").exists()
     assert not (voices_dir / "OldUnassigned").exists()
 
-def test_add_variant_to_unassigned(clean_db, tmp_path):
-    voices_dir = tmp_path / "voices"
+def test_add_variant_to_unassigned(clean_db, voices_root):
+    voices_dir = voices_root
     voices_dir.mkdir()
-    fastapi_app.dependency_overrides[get_voices_dir] = lambda: voices_dir
 
     # 1. Create an unassigned profile base
     (voices_dir / "FreshVoice").mkdir()
@@ -85,10 +93,9 @@ def test_add_variant_to_unassigned(clean_db, tmp_path):
     assert meta["speaker_id"] == "FreshVoice"
     assert meta["variant_name"] == "Variant1"
 
-def test_rename_unassigned_profile_payload(clean_db, tmp_path):
-    voices_dir = tmp_path / "voices"
+def test_rename_unassigned_profile_payload(clean_db, voices_root):
+    voices_dir = voices_root
     voices_dir.mkdir()
-    fastapi_app.dependency_overrides[get_voices_dir] = lambda: voices_dir
 
     profile_path = voices_dir / "OldName"
     profile_path.mkdir()
@@ -99,9 +106,9 @@ def test_rename_unassigned_profile_payload(clean_db, tmp_path):
     assert response.status_code == 200
     assert (voices_dir / "NewName").exists()
 
-def test_default_variant_resolution(clean_db, tmp_path):
+def test_default_variant_resolution(clean_db, voices_root):
     import app.jobs.speaker
-    voices_dir = tmp_path / "voices"
+    voices_dir = voices_root
     voices_dir.mkdir()
     app.jobs.speaker.VOICES_DIR = voices_dir
 
@@ -157,11 +164,10 @@ def test_reconcile_does_not_requeue_voice_jobs(clean_db, tmp_path):
     assert result.status == "done", f"Expected 'done' but got '{result.status}' — reconcile incorrectly requeued a voice job!"
 
 
-def test_assign_profile_to_different_speaker(clean_db, tmp_path):
+def test_assign_profile_to_different_speaker(clean_db, voices_root):
     """Assigning a profile to a different speaker renames the folder correctly."""
-    voices_dir = tmp_path / "voices"
+    voices_dir = voices_root
     voices_dir.mkdir()
-    fastapi_app.dependency_overrides[get_voices_dir] = lambda: voices_dir
 
     # Create two speakers
     sid_dracula = create_speaker("Dracula")
@@ -203,11 +209,10 @@ def test_worker_does_not_skip_voice_builds():
         "worker_loop must exclude voice engines from the output-exists skip check"
 
 
-def test_build_clears_sample_wav(clean_db, tmp_path):
+def test_build_clears_sample_wav(clean_db, voices_root):
     """Calling the build endpoint should delete an existing sample.wav."""
-    voices_dir = tmp_path / "voices"
+    voices_dir = voices_root
     voices_dir.mkdir(parents=True, exist_ok=True)
-    fastapi_app.dependency_overrides[get_voices_dir] = lambda: voices_dir
 
     # 1. Create a profile, a raw sample, and a sample.wav preview file
     profile_path = voices_dir / "TestBuilder"
@@ -228,15 +233,14 @@ def test_build_clears_sample_wav(clean_db, tmp_path):
     assert raw_sample_path.exists(), "raw samples should remain available for the build job"
 
 
-def test_voice_build_worker_exports_mp3_preview(clean_db, tmp_path):
+def test_voice_build_worker_exports_mp3_preview(clean_db, voices_root):
     """Voice build jobs should leave a reusable sample.mp3 and remove the temp sample.wav."""
     from app.jobs.worker import worker_loop
     from app.models import Job
 
-    voices_dir = tmp_path / "voices"
+    voices_dir = voices_root
     profile_dir = voices_dir / "TestBuilt"
     profile_dir.mkdir(parents=True, exist_ok=True)
-    fastapi_app.dependency_overrides[get_voices_dir] = lambda: voices_dir
 
     sample_wav = profile_dir / "sample.wav"
     sample_mp3 = profile_dir / "sample.mp3"


### PR DESCRIPTION
## Summary

This PR follows up on the recent CodeQL cleanup by correcting the last regression in the voices router path hardening work and preserving compatibility across the API, middleware, and tests.

The main goal of this batch was:
- keep the scanner-friendly `voices.py` path handling shape
- remove stale call patterns that were still reintroducing the old flow
- restore compatibility for routes and tests that depended on the earlier voices directory seam
- get the full backend suite green again before the next scan

## What Changed

### Voices Router Cleanup
- Continued the `app/api/routers/voices.py` refactor so path handling stays rooted in the module-level `VOICES_DIR` instead of threading a `voices_dir` path through every route.
- Removed the last leftover `voices_dir` reference in the voice test preview flow.
- Kept a small `get_voices_dir()` compatibility shim so older tests and route wiring still have a stable seam without reintroducing the previous taint-heavy pattern.

### System Route Compatibility
- Updated `app/api/routers/system.py` so `/api/home` no longer calls `list_speaker_profiles(voices_dir=...)`.
- This keeps the home endpoint aligned with the new voices router contract and fixes the compatibility break that showed up in the full suite.

### Test Harness Alignment
- Updated the voices-related test fixtures to patch all relevant voice roots consistently:
  - `app.web.VOICES_DIR`
  - `app.config.VOICES_DIR`
  - `app.api.routers.voices.VOICES_DIR`
  - `app.jobs.speaker.VOICES_DIR`
- This avoids the middleware sync from resetting the test voice root during requests and gives the tests the same effective runtime configuration the app uses.

## Files Touched

- `app/api/routers/voices.py`
- `app/api/routers/system.py`
- `tests/test_api_voices.py`
- `tests/test_speaker_refinement.py`

## Why This Matters

The previous batch was structurally in the right direction for CodeQL, but it exposed a compatibility gap:
- the voices router contract had changed
- the system home endpoint still used the old call signature
- the middleware was also overwriting the test voice root during requests

This PR closes those seams so the CodeQL-oriented refactor and the runtime/test behavior are working together instead of fighting each other.

## Notes

This PR is intended to stabilize the voices-router path hardening work before the next code scanning run, so the next scan reflects the actual security shape instead of compatibility fallout.
