### PR TITLE
fix(mac/linux): fix ModuleNotFoundError for demo installation

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -255,7 +255,7 @@ maybe_restore_demo_bundle() {
 
   [[ -f "$DEMO_ZIP" ]] || return 0
 
-  if ! "$PYTHON_BIN" -m app.demo_bundle status --base-dir "$DIR"; then
+  if ! ( cd "$DIR" && "$PYTHON_BIN" -m app.demo_bundle status --base-dir "$DIR" ); then
     return 0
   fi
 
@@ -281,7 +281,7 @@ maybe_restore_demo_bundle() {
   esac
 
   log "Installing demo library"
-  "$PYTHON_BIN" -m app.demo_bundle restore --base-dir "$DIR" --zip "$DEMO_ZIP"
+  ( cd "$DIR" && "$PYTHON_BIN" -m app.demo_bundle restore --base-dir "$DIR" --zip "$DEMO_ZIP" )
 }
 
 require_cmd bash


### PR DESCRIPTION
### **Description:**
This PR resolving an issue on macOS/Linux environments where the demo bundle occasionally failed to install smoothly during automated initialization setups. 

### **The Problem:**
When Pinokio initializes the application on macOS or Linux, it correctly triggers `run.sh` natively from the Pinokio root workspace level. Because `run.sh` did not explicitly `cd` into the cloned repository’s root before executing the `app.demo_bundle` Python package, Python threw a `ModuleNotFoundError` because it was attempting to resolve the `app` package directly from Pinokio's execution scope. 

### **The Changes:**
- Neatly enveloped the status and installation Python commands within `run.sh` into explicit `( cd "$DIR" && ... )` subshells. 
- This guarantees that no matter where the shell is invoked from, the Python execution effortlessly snaps into the repository working directory, matches identical pathing behavior successfully utilized dynamically inside `run.ps1` for Windows, and properly unpacks the demo libraries.